### PR TITLE
Added higher mass units in MassConverter

### DIFF
--- a/UnitConversion/MassConverter.cs
+++ b/UnitConversion/MassConverter.cs
@@ -22,6 +22,9 @@ namespace UnitConversion
             { new UnitFactorSynonyms("lb", "lbs", "pound", "pounds"), 100000000d / 45359237 },
             { new UnitFactorSynonyms("st", "stone"), 50000000d / 317514659 },
             { new UnitFactorSynonyms("oz", "ounce"), 1600000000d / 45359237 },
+            { new UnitFactorSynonyms("quintal"), 0.01 },
+            { new UnitFactorSynonyms("short ton", "net ton", "us ton"), 0.00110231 },
+            { new UnitFactorSynonyms("long ton", "weight ton", "gross ton", "imperial ton"), 0.000984207 },
         };
 
         public MassConverter(string leftUnit, string rightUnit)

--- a/UnitConversionTests/MassConverterTests.cs
+++ b/UnitConversionTests/MassConverterTests.cs
@@ -66,5 +66,38 @@ namespace UnitConversionTests {
             Assert.AreEqual(valR, converter.LeftToRight(valL, 3));
             Assert.AreEqual(valL, converter.RightToLeft(valR, 3));
         }
+
+        [TestMethod()]
+        public void kg_quintal()
+        {
+            converter = new MassConverter("quintal", "kg");
+            double valL = 1;
+            double valR = 100;
+
+            Assert.AreEqual(valR, converter.LeftToRight(valL));
+            Assert.AreEqual(valL, converter.RightToLeft(valR));
+        }
+
+        [TestMethod()]
+        public void kg_uston()
+        {
+            converter = new MassConverter("us ton", "kg");
+            double valL = 1;
+            double valR = 907.18582;
+
+            Assert.AreEqual(valR, converter.LeftToRight(valL, 5));
+            Assert.AreEqual(valL, converter.RightToLeft(valR, 5));
+        }
+
+        [TestMethod()]
+        public void kg_imperialton()
+        {
+            converter = new MassConverter("imperial ton", "kg");
+            double valL = 1;
+            double valR = 1016.04642;
+
+            Assert.AreEqual(valR, converter.LeftToRight(valL, 5));
+            Assert.AreEqual(valL, converter.RightToLeft(valR, 5));
+        }
     }
 }


### PR DESCRIPTION
Added KgToQuintal, KgToShortTon, KgToLongTon converter in MassConverter.cs file.
Added unit tests for the same.

Reference:
[CCST-Conversion-Docuement](https://www.isa.org/uploadedFiles/Content/Training_and_Certifications/ISA_Certification/CCST-Conversions-document.pdf)
[Google - kg to quintal](https://www.google.co.in/search?ei=zAkHW8HbCcXbvAS70qOYBw&q=kg+to+quintal&oq=kg+to+q&gs_l=psy-ab.3.0.35i39k1j0l8.3665.3665.0.5477.1.1.0.0.0.0.118.118.0j1.1.0....0...1.1.64.psy-ab..0.1.117....0.ErLmVf0diBU)


